### PR TITLE
change up the syntax of consumer template

### DIFF
--- a/src/templates/artifacts/Consumer.groovy
+++ b/src/templates/artifacts/Consumer.groovy
@@ -4,9 +4,8 @@ class @artifact.name@ {
     /**
      * Consumer configuration.
      */
-    static rabbitConfig = [
-        : // TODO: Setup config.
-    ]
+    // TODO: Setup config.
+    static rabbitConfig = [:]
 
     /**
      * Handle an incoming RabbitMQ message.


### PR DESCRIPTION
I **think** this will fix issue #8 but I did not get a chance to test it yet. If not I think adding the map like:

``` groovy
        static rabbitConfig = [ '' : '' ]
```

Will do it. We can test tomorrow.
