### PR TITLE
Publish documentation

### DIFF
--- a/doc/manual/guide/publishing.html
+++ b/doc/manual/guide/publishing.html
@@ -121,8 +121,8 @@ Sending a message means publishing a message to an exchange or queue and not wai
 are a queue or exchange to publish the message to, and the body of the message.<p class="paragraph"/><h4>Send Example</h4>
 <div class="code"><pre>// Send a message
 <span class="java&#45;keyword">new</span> RabbitMessageBuilder().send &#123;
-    exchange = "some.exchange"
-    routingKey = <span class="java&#45;quote">"some.key"</span>
+    exchange = <span class="java&#45;quote">"some.exchange"</span>
+    routingKey = <span class="java&#45;quote">"some.routingkey"</span>
     body = <span class="java&#45;quote">"hi!"</span>
 &#125;</pre></div><p class="paragraph"/>RabbitMQ expects the body of a message to be a byte array. Message converters will also work when publishing messages, so if an object type other than <code>byte</code> is
 encountered, a suitable message converter will be found and run against the message body, if one exists.
@@ -133,7 +133,8 @@ encountered, a suitable message converter will be found and run against the mess
 Publishing an RPC message is as easy as sending messages, except the returned message is returned from the function.<p class="paragraph"/><h4>RPC Example</h4>
 <div class="code"><pre>// Send a message
 def result = <span class="java&#45;keyword">new</span> RabbitMessageBuilder().rpc &#123;
-    routingKey = <span class="java&#45;quote">"some.queue"</span>
+    exchange = <span class="java&#45;quote">"some.exchange"</span>
+    routingKey = <span class="java&#45;quote">"some.routingkey"</span>
     body = <span class="java&#45;quote">"hi!"</span>
     timeout = RabbitMessageBuilder.DEFAULT_TIMEOUT
 &#125;</pre></div><p class="paragraph"/><blockquote class="warning">


### PR DESCRIPTION
I've added the exchange name to the publish documentation and renamed the variable used as the routing key to make the example clearer.
