### PR TITLE
Allow to use application's configuration to setup listeners

### DIFF
--- a/RabbitmqNativeGrailsPlugin.groovy
+++ b/RabbitmqNativeGrailsPlugin.groovy
@@ -33,7 +33,7 @@ class RabbitmqNativeGrailsPlugin {
     /**
      * Version of the plugin.
      */
-    def version = "2.0.10"
+    def version = "2.0.11"
 
     /**
      * The version or versions of Grails the plugin is designed for.

--- a/src/docs/guide/consuming/queues.gdoc
+++ b/src/docs/guide/consuming/queues.gdoc
@@ -1,8 +1,11 @@
 Message consumers can subscribe to either queues or exchanges. When a consumer is registered to a queue, the consumer will receive messages from the queue as
 the RabbitMQ server determines that it's the consumer's turn to receive a message, since there may be multiple listeners on the same queue.
 
-Each message consumer class must have a configuration defined.  The configuration should be a Map, assigned to a static variable named @rabbitConfig@. To
-subscribe to queues, the only required configuration option is the @queue@ variable, which is the name of the queue to subscribe to.
+Each message consumer class must have a configuration defined. There are 2 possible options to specify the configuration:
+
+* The configuration should be a Map, assigned to a static variable named @rabbitConfig@. To subscribe to queues, the only
+ required configuration option is the @queue@ variable, which is the name of the queue to subscribe to.
+* Using @rabbitmq.consumers.<ClassName>@ in the application's configuration file
 
 Here is a simple example of a consumer subscribing to a queue.
 {code}
@@ -15,6 +18,17 @@ class ExampleConsumer {
 
     def handleMessage(def body, MessageContext context) {
         // Process message
+    }
+}
+{code}
+The exact same configuration would be defined using this in the application's Config.groovy
+{code}
+// ...
+rabbitmq {
+    consumers {
+        ExampleConsumer {
+            queue: "test.queue"
+        }
     }
 }
 {code}

--- a/src/groovy/com/budjb/rabbitmq/ConsumerConfiguration.groovy
+++ b/src/groovy/com/budjb/rabbitmq/ConsumerConfiguration.groovy
@@ -89,6 +89,10 @@ class ConsumerConfiguration {
         }
     }
 
+    public ConsumerConfiguration(ConfigObject options) {
+        this(buildMap(options))
+    }
+
     /**
      * Assigns the option provided by the consumer's config, or returns the default
      * value if the option was not provided or it was unable to be converted to
@@ -107,6 +111,20 @@ class ConsumerConfiguration {
         }
         catch (Exception e) {
             return defaultValue
+        }
+    }
+
+    /**
+     * builds a Map instance from a config object
+     *
+     * @param config a ConfigObject instance to transform into a Map
+     * @return the resulting Map instance
+     */
+    static private buildMap(ConfigObject config) {
+        if (config) {
+            return config.collectEntries {it}
+        } else {
+            return [:]
         }
     }
 }


### PR DESCRIPTION
Hi, 

The application i'm currently working on requires that consumers listen to different queues based on configuration (this would be required for most topic exchange based configurations, i think).

This patch simply modifies the `RabbitConsumer.isConsumer()` method to fallback to application's `Config.groovy` `rabbitmq.consumers.<ClassName>` if it can't find `rabbitConfig`. The `startConsumer` method has been modified accordingly. I have added many `debug()` calls that could easily be discarded.

I've been using this version 2.0.11 for a while without any issue, hosting it on a local artifactory repo.