### PR TITLE
Update RabbitMessageBuilder.groovy

### DIFF
--- a/src/groovy/com/budjb/rabbitmq/RabbitMessageBuilder.groovy
+++ b/src/groovy/com/budjb/rabbitmq/RabbitMessageBuilder.groovy
@@ -349,7 +349,7 @@ class RabbitMessageBuilder {
      */
     protected void run(Closure closure) {
         closure.delegate = this
-        closure.resolveStrategy = Closure.OWNER_FIRST
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
         closure.run()
     }
 }


### PR DESCRIPTION
If the resolve strategy is OWNER_FIRST the plugin cannot be used in controllers with cache-header plugin because it uses a closure like  this: 

withCacheHeaders {
			etag {
				getETag name: 'user', id: id
			}
			generate {
				def result = new RabbitMessageBuilder().rpc {
						exchange = 'core_rpc'
						routingKey = 'user.getUserData'
						body = [id: id]
						timeout = RabbitMessageBuilder.DEFAULT_TIMEOUT
					}
				renderResponse(result)
				cache 'short_term' // for history navigation (5 sec)
			}
		}

It needs to be DELEGATE_FIRST so the closure can refer to the RabbitMessageBuilder to write exchange and other properties.

Do you think it's possible to have a new plugin release if the pull request it's accepted?