### PR TITLE
Update timestamp example

### DIFF
--- a/rabbitmq-native/src/docs/ref/Rabbit Message Publisher/timestamp.gdoc
+++ b/rabbitmq-native/src/docs/ref/Rabbit Message Publisher/timestamp.gdoc
@@ -9,7 +9,7 @@ h2. Examples
 {code}
 rabbitMessagePublisher.send {
     routingKey = "example.queue"
-    messageId = "1234"
+    timestamp = Calendar.getInstance()
     body = "test message"
 }
 {code}


### PR DESCRIPTION
The example for `timestamp` doesn't show its usage, so it's hard to tell that it actually needs a `Calendar` object. 