### PR TITLE
Added TypeConvertingMapMessageConverter.

### DIFF
--- a/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/converter/TypeConvertingMapMessageConverter.groovy
+++ b/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/converter/TypeConvertingMapMessageConverter.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2016 Bud Byrd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.budjb.rabbitmq.converter
+
+import grails.util.TypeConvertingMap
+import groovy.json.JsonBuilder
+import groovy.json.JsonException
+import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class TypeConvertingMapMessageConverter extends MessageConverter<TypeConvertingMap> {
+    @Override
+    boolean canConvertFrom() {
+        return true
+    }
+
+    @Override
+    boolean canConvertTo() {
+        return true
+    }
+
+    @Override
+    TypeConvertingMap convertTo(byte[] input) {
+        try {
+            def parsed = new JsonSlurper().parseText(new String(input))
+
+            if (parsed instanceof Map) {
+                return new TypeConvertingMap(parsed)
+            }
+
+            return null
+        }
+        catch (Exception e) {
+            log.trace("error parsing JSON", e)
+            return null
+        }
+    }
+
+    @Override
+    byte[] convertFrom(TypeConvertingMap input) {
+        try {
+            return new JsonBuilder(input).toString().getBytes()
+        }
+        catch (JsonException e) {
+            log.trace("error creating JSON", e)
+            return null
+        }
+    }
+
+    @Override
+    String getContentType() {
+        return 'application/json'
+    }
+
+}

--- a/rabbitmq-native/src/test/groovy/com/budjb/rabbitmq/test/converter/TypeConvertingMapMessageConverterSpec.groovy
+++ b/rabbitmq-native/src/test/groovy/com/budjb/rabbitmq/test/converter/TypeConvertingMapMessageConverterSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Bud Byrd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.budjb.rabbitmq.test.converter
+
+import com.budjb.rabbitmq.converter.TypeConvertingMapMessageConverter
+import grails.util.TypeConvertingMap
+import spock.lang.Specification
+
+class TypeConvertingMapMessageConverterSpec extends Specification {
+    TypeConvertingMapMessageConverter messageConverter
+
+    def setup() {
+        messageConverter = new TypeConvertingMapMessageConverter()
+    }
+
+    def 'Ensure the converter reports that it can convert from a map'() {
+        messageConverter.canConvertFrom() == true
+    }
+
+    def 'Ensure the converter reports that it can convert to a map'() {
+        messageConverter.canConvertTo() == true
+    }
+
+    def 'Validate conversion from a byte array'() {
+        setup:
+        byte[] source = [123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125] as byte[]
+
+        when:
+        TypeConvertingMap converted = messageConverter.convertTo(source)
+
+        then:
+        converted == ["foo": "bar"] as TypeConvertingMap
+    }
+
+    def 'Validate conversion to a byte array'() {
+        setup:
+        TypeConvertingMap list = ["foo": "bar"]
+
+        when:
+        byte[] converted = messageConverter.convertFrom(list)
+
+        then:
+        converted == [123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125] as byte[]
+    }
+
+    def 'Ensure the converter has the correct content type'() {
+        messageConverter.getContentType() == 'application/json'
+    }
+}


### PR DESCRIPTION
Enables the use of the following `handleMessage` signature:

```groovy
def handleMessage(TypeConvertingMap body) {
    // Use classes, not datatypes.
    Integer foo = body.int('foo')

    // This would throw an error if body.foo == '42a'
    // int foo = body.int('foo')
}
```

(Inclusion of **MessageContext** parameter is the same, just not explicitly provided)