### PR TITLE
Add ClientProperties

### DIFF
--- a/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/connection/ConnectionConfiguration.groovy
+++ b/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/connection/ConnectionConfiguration.groovy
@@ -131,4 +131,14 @@ interface ConnectionConfiguration extends RabbitManagedContextConfiguration {
      * Sets whether to use SSL.
      */
     void setSsl(boolean ssl)
+
+    /**
+     * Sets custom client properties
+     */
+    void setClientProperties(Map<String, Object> clientProperties)
+
+    /**
+     * Returns the client properties
+     */
+    Map<String, Object> getClientProperties()
 }

--- a/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/connection/ConnectionConfigurationImpl.groovy
+++ b/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/connection/ConnectionConfigurationImpl.groovy
@@ -84,6 +84,11 @@ class ConnectionConfigurationImpl implements ConnectionConfiguration {
     int port = ConnectionFactory.DEFAULT_AMQP_PORT
 
     /**
+     * Add custom client properties
+     */
+    Map<String, Object> clientProperties
+
+    /**
      * Basic constructor.
      */
     ConnectionConfigurationImpl() {}
@@ -105,6 +110,7 @@ class ConnectionConfigurationImpl implements ConnectionConfiguration {
         setThreads(parseConfigOption(Integer, configuration['threads'], threads))
         setUsername(parseConfigOption(String, configuration['username'], username))
         setVirtualHost(parseConfigOption(String, configuration['virtualHost'], virtualHost))
+        setClientProperties(parseConfigOption(Map, configuration['clientProperties'], clientProperties))
     }
 
     /**

--- a/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/connection/ConnectionContextImpl.groovy
+++ b/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/connection/ConnectionContextImpl.groovy
@@ -89,6 +89,10 @@ class ConnectionContextImpl implements ConnectionContext {
         factory.setAutomaticRecoveryEnabled(configuration.getAutomaticReconnect())
         factory.setRequestedHeartbeat(configuration.getRequestedHeartbeat())
 
+        if (configuration.getClientProperties()) {
+            factory.setClientProperties(factory.getClientProperties() + configuration.getClientProperties())
+        }
+
         if (configuration.getSsl()) {
             factory.useSslProtocol()
         }

--- a/rabbitmq-native/src/test/groovy/com/budjb/rabbitmq/test/connection/ConnectionConfigurationImplSpec.groovy
+++ b/rabbitmq-native/src/test/groovy/com/budjb/rabbitmq/test/connection/ConnectionConfigurationImplSpec.groovy
@@ -153,7 +153,7 @@ class ConnectionConfigurationImplSpec extends Specification {
         configuration.setSsl(true)
         configuration.setThreads(10)
         configuration.setVirtualHost('test-virtual-host')
-        configuration.setClientProperties(['applicationName': 'jUnit-Test', 'appVersion': '0.0.2'])
+        configuration.setClientProperties(['applicationName': 'TestApp', 'appVersion': '0.0.2'])
 
         then:
         configuration.getHost() == 'test-host'
@@ -167,6 +167,6 @@ class ConnectionConfigurationImplSpec extends Specification {
         configuration.getSsl() == true
         configuration.getThreads() == 10
         configuration.getVirtualHost() == 'test-virtual-host'
-        configuration.getClientProperties() == ['applicationName': 'jUnit-Test', 'appVersion': '0.0.2']
+        configuration.getClientProperties() == ['applicationName': 'TestApp', 'appVersion': '0.0.2']
     }
 }

--- a/rabbitmq-native/src/test/groovy/com/budjb/rabbitmq/test/connection/ConnectionConfigurationImplSpec.groovy
+++ b/rabbitmq-native/src/test/groovy/com/budjb/rabbitmq/test/connection/ConnectionConfigurationImplSpec.groovy
@@ -116,7 +116,7 @@ class ConnectionConfigurationImplSpec extends Specification {
             'ssl': true,
             'threads': 10,
             'virtualHost': 'test-virtual-host',
-            'clientProperties' : ['applicationName': 'jUnit-Test', 'appVersion': '0.0.1']
+            'clientProperties' : ['applicationName': 'TestApp', 'appVersion': '0.0.1']
         ]
 
         when:
@@ -134,7 +134,7 @@ class ConnectionConfigurationImplSpec extends Specification {
         connectionConfiguration.getSsl() == true
         connectionConfiguration.getThreads() == 10
         connectionConfiguration.getVirtualHost() == 'test-virtual-host'
-        connectionConfiguration.getClientProperties() == ['applicationName': 'jUnit-Test', 'appVersion': '0.0.1']
+        connectionConfiguration.getClientProperties() == ['applicationName': 'TestApp', 'appVersion': '0.0.1']
     }
 
     def 'Test that setters work correctly'() {

--- a/rabbitmq-native/src/test/groovy/com/budjb/rabbitmq/test/connection/ConnectionConfigurationImplSpec.groovy
+++ b/rabbitmq-native/src/test/groovy/com/budjb/rabbitmq/test/connection/ConnectionConfigurationImplSpec.groovy
@@ -115,7 +115,8 @@ class ConnectionConfigurationImplSpec extends Specification {
             'requestedHeartbeat': 1000,
             'ssl': true,
             'threads': 10,
-            'virtualHost': 'test-virtual-host'
+            'virtualHost': 'test-virtual-host',
+            'clientProperties' : ['applicationName': 'jUnit-Test', 'appVersion': '0.0.1']
         ]
 
         when:
@@ -133,6 +134,7 @@ class ConnectionConfigurationImplSpec extends Specification {
         connectionConfiguration.getSsl() == true
         connectionConfiguration.getThreads() == 10
         connectionConfiguration.getVirtualHost() == 'test-virtual-host'
+        connectionConfiguration.getClientProperties() == ['applicationName': 'jUnit-Test', 'appVersion': '0.0.1']
     }
 
     def 'Test that setters work correctly'() {
@@ -151,6 +153,7 @@ class ConnectionConfigurationImplSpec extends Specification {
         configuration.setSsl(true)
         configuration.setThreads(10)
         configuration.setVirtualHost('test-virtual-host')
+        configuration.setClientProperties(['applicationName': 'jUnit-Test', 'appVersion': '0.0.2'])
 
         then:
         configuration.getHost() == 'test-host'
@@ -164,5 +167,6 @@ class ConnectionConfigurationImplSpec extends Specification {
         configuration.getSsl() == true
         configuration.getThreads() == 10
         configuration.getVirtualHost() == 'test-virtual-host'
+        configuration.getClientProperties() == ['applicationName': 'jUnit-Test', 'appVersion': '0.0.2']
     }
 }


### PR DESCRIPTION
Add ability to add custom client properties. 

The use case was for the ability to add something like application name or version to the client properties of rabbit.