### PR TITLE
[#130]: Added rabbitmq prefix, to avoid conflicts with environment variables.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ gormVersion=6.0.12.RELEASE
 
 org.gradle.daemon=true
 
-version=3.4.4
+version=3.4.5
 group=org.grails.plugins
 
 sourceCompatibility=1.8

--- a/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/utils/ConfigPropertyResolver.groovy
+++ b/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/utils/ConfigPropertyResolver.groovy
@@ -16,6 +16,7 @@
 package com.budjb.rabbitmq.utils
 
 import grails.config.Config
+import org.grails.config.PrefixedConfig
 import org.grails.config.PropertySourcesConfig
 
 import java.util.regex.Matcher
@@ -43,7 +44,7 @@ trait ConfigPropertyResolver {
      * @return a map with all values remapped where necessary
      */
     Config fixPropertyResolution(Map map) {
-        return new PropertySourcesConfig((Map) map.collectEntries { k, v ->
+        PropertySourcesConfig config =  new PropertySourcesConfig((Map) map.collectEntries { k, v ->
             def val = v
             if (val instanceof String) {
                 Matcher m = Pattern.compile(/\$\{(.+?)}/).matcher(val)
@@ -51,7 +52,9 @@ trait ConfigPropertyResolver {
                     val = grailsConfiguration.get(m.group(1))
                 }
             }
-            return [k, val]
+            return ['rabbitmq.' + k, val]
         })
+
+        new PrefixedConfig('rabbitmq', config)
     }
 }


### PR DESCRIPTION
Hi @budjb , could you please review this PR, it adds internal prefix `rabbitmq` to all configs to avoid conflicts with environment variables. Note that all external configurations will work as before, nothing need to be changed. If you will be able to publish this change, that would be really great as I will be able to use this plugin with Grails 3.3.6.

Thanks for this plugin and thanks for reviewing my PR. Gevorg