### PR TITLE
Better validation check for the binding configuration property

### DIFF
--- a/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/consumer/ConsumerConfigurationImpl.groovy
+++ b/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/consumer/ConsumerConfigurationImpl.groovy
@@ -178,7 +178,7 @@ class ConsumerConfigurationImpl implements ConsumerConfiguration {
             valid = false
         }
 
-        if (binding instanceof Map && !(match in ["any", "all"])) {
+        if (!queue && binding instanceof Map && !(match in ["any", "all"])) {
             log.warn("match must be either 'any' or 'all'")
             valid = false
         }

--- a/rabbitmq-native/src/test/groovy/com/budjb/rabbitmq/test/consumer/ConsumerConfigurationImplSpec.groovy
+++ b/rabbitmq-native/src/test/groovy/com/budjb/rabbitmq/test/consumer/ConsumerConfigurationImplSpec.groovy
@@ -139,4 +139,30 @@ class ConsumerConfigurationImplSpec extends Specification {
         then:
         configuration.getAutoAck() == AutoAck.POST
     }
+
+    def 'Validate isValid'() {
+        when:
+            ConsumerConfigurationImpl configuration = new ConsumerConfigurationImpl()
+
+        then:
+            configuration.isValid() == false
+
+        when:
+            configuration = new ConsumerConfigurationImpl([queue: 'test-queue'])
+
+        then:
+            configuration.isValid() == true
+
+        when:
+            configuration = new ConsumerConfigurationImpl([queue: 'test-queue', exchange: 'test-exchange'])
+
+        then:
+            configuration.isValid() == false
+
+        when:
+            configuration = new ConsumerConfigurationImpl([queue: 'test-queue', binding: [:]])
+
+        then:
+            configuration.isValid() == true
+    }
 }


### PR DESCRIPTION
This should fix issue #134 by checking for the values of the binding and match configuration properties only when there is no queue set (i.e., when the consumer is configured for an exchange).

It also adds some unit test coverage for the consumer configuration validation.