### PR TITLE
Eliminate use of MimeType.getCharSet

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
-grailsVersion=3.2.11
+grailsVersion=3.3.0
 gradleWrapperVersion=3.4.1
 gormVersion=6.0.12.RELEASE
 
 org.gradle.daemon=true
 
-version=3.4.6
+version=4.0.0
 group=org.grails.plugins
 
 sourceCompatibility=1.8

--- a/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/converter/ByteToObjectInput.groovy
+++ b/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/converter/ByteToObjectInput.groovy
@@ -113,6 +113,6 @@ class ByteToObjectInput {
      * @return
      */
     Charset getCharset() {
-        return mimeType?.getCharSet() ?: UTF_8
+        return mimeType?.getCharset() ?: UTF_8
     }
 }


### PR DESCRIPTION
This is to allow for this plugin to be used in Grails 4.

Spring has removed the MimeType.getCharSet method entirely in favor of
the MimeType.getCharset method as of Spring 5.  Making this change
allows the rabbitmq-native plugin to function with versions of Grails
3.3 and greater, including Grails 4.

The version of the plugin has been bumped to 4.0.0 to comply with
semver, indicating a breaking change since this will mean the plugin
will not work with versions of Grails prior to 3.3.