### PR TITLE
Fix config deprecation warning for Grails 5

### DIFF
--- a/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/queuebuilder/QueueBuilderImpl.groovy
+++ b/rabbitmq-native/src/main/groovy/com/budjb/rabbitmq/queuebuilder/QueueBuilderImpl.groovy
@@ -68,18 +68,15 @@ class QueueBuilderImpl implements QueueBuilder, ConfigPropertyResolver {
         queues.clear()
         exchanges.clear()
 
-        def topConfig = grailsApplication.config.rabbitmq
+        Map topConfig = grailsApplication.config.getProperty("rabbitmq", Map, [:])
         def queueConfig = topConfig.queues
 
         if (queueConfig instanceof Closure) {
             log.warn("closure-based configuration for queues and exchanges is deprecated")
             call(queueConfig, new ClosureDelegate())
         }
-        else if (topConfig instanceof Map) {
+        else  {
             parse(topConfig as Map)
-        }
-        else {
-            throw new InvalidConfigurationException("queue/exchanges configuration is invalid")
         }
 
         queues*.validate()


### PR DESCRIPTION
There is a deprecation warning when using this plugin in Grails 5:

```
Accessing config key 'queues' through dot notation is deprecated, and it will be removed in a future release. Use 'config.getProperty(key, targetClass)' instead
```

Variations of this message appear for the keys:
- `queues`
- `exchanges`

By obtaining the config using `getProperty` at the root level, these notifications are not emitted.